### PR TITLE
Add dotfiles-installer manifest

### DIFF
--- a/.dotfiles-manifest.json
+++ b/.dotfiles-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0.0",
   "generatedBy": "dotfiles-installer@1.0.0",
-  "generatedAt": "2026-04-05T02:29:56.948Z",
+  "generatedAt": "2026-04-05T03:05:57.236Z",
   "repository": {
     "url": "https://github.com/schnej7/dotfiles",
     "ref": "main"
@@ -11,6 +11,12 @@
     "linux"
   ],
   "actions": [
+    {
+      "type": "hook",
+      "name": "Start",
+      "command": "echo \"Installation start\"",
+      "when": "pre"
+    },
     {
       "type": "symlink",
       "source": "bash/aliases.bash",
@@ -82,6 +88,12 @@
       "source": "cursor_bashrc.sh",
       "target": "~/.cursor_bashrc.sh",
       "overwrite": false
+    },
+    {
+      "type": "hook",
+      "name": "End",
+      "command": "echo \"Installation end\"",
+      "when": "post"
     }
   ],
   "dependencies": [
@@ -153,6 +165,13 @@
       "install": {
         "brew": "gh",
         "apt": "gh"
+      }
+    },
+    {
+      "name": "jq",
+      "install": {
+        "brew": "jq",
+        "apt": "jq"
       }
     }
   ]


### PR DESCRIPTION
This PR adds a `.dotfiles-manifest.json` file generated by [dotfiles-installer](https://github.com/jeromesch/dotfiles-installer).

Once merged, anyone can install this repo with:

```bash
curl -fsSL https://raw.githubusercontent.com/jeromesch/dotfiles-installer/main/installer/install.sh | bash -s -- schnej7/dotfiles
```