### PR TITLE
Add dotfiles-installer manifest

### DIFF
--- a/.dotfiles-manifest.json
+++ b/.dotfiles-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0.0",
   "generatedBy": "dotfiles-installer@1.0.0",
-  "generatedAt": "2026-04-05T03:25:04.602Z",
+  "generatedAt": "2026-04-05T03:35:39.148Z",
   "repository": {
     "url": "https://github.com/schnej7/dotfiles",
     "ref": "main"


### PR DESCRIPTION
This PR adds a `.dotfiles-manifest.json` file generated by [dotfiles-installer](https://github.com/schnej7/dotfiles-installer).

Once merged, anyone can install this repo with:

```bash
curl -fsSL https://raw.githubusercontent.com/schnej7/dotfiles-installer/main/installer/install.sh | bash -s -- schnej7/dotfiles
```