### PR TITLE
Add dotfiles-installer manifest

### DIFF
--- a/.dotfiles-manifest.json
+++ b/.dotfiles-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0.0",
   "generatedBy": "dotfiles-installer@1.0.0",
-  "generatedAt": "2026-04-05T03:25:04.602Z",
+  "generatedAt": "2026-04-11T03:07:46.330Z",
   "repository": {
     "url": "https://github.com/schnej7/dotfiles",
     "ref": "main"
@@ -82,6 +82,12 @@
       "source": "cursor_bashrc.sh",
       "target": "~/.cursor_bashrc.sh",
       "overwrite": false
+    },
+    {
+      "type": "hook",
+      "name": "source",
+      "command": "source ~/.bashrc",
+      "when": "post"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
This PR adds a `.dotfiles-manifest.json` file generated by [dotfiles-installer](https://github.com/dotfiles-installer/curlme).

Once merged, anyone can install this repo with:

```bash
curl -fsSL https://raw.githubusercontent.com/dotfiles-installer/curlme/main/sh | bash -s -- schnej7/dotfiles
```